### PR TITLE
Fix `TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.` error in tests

### DIFF
--- a/apps/ts-interface/tests/tsconfig.json
+++ b/apps/ts-interface/tests/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "../../../tsconfig.compiler-options.json",
   "compilerOptions": {
     "baseUrl": ".",
+    "rootDir": "../",
     "declarationDir": "../declarations/tests",
     "paths": {
       "ts-interface/tests/*": ["./*"],
@@ -14,7 +15,7 @@
        "my-addon/test-support/*": ["../../../packages/my-addon/declarations/tests/*"]
     },
   },
-  "include": [".", "../types"],
+  "include": [".", "../types", "../app"],
   "references": [
     { "path": "../app/tsconfig.json" },
 


### PR DESCRIPTION
Adding `"../app"` to the tests tsconfig includes seems to get TS to pickup on the additional `moes` entry in `BarRegistry`

I also ran into compile errors with `yarn tsc --build --force` until I also added `"rootDir": "../",`
    
Errors:
```
$ yarn tsc --build --force
yarn run v1.22.17
$ ~/Projects/vitch/ts-interface/node_modules/.bin/tsc --build --force
error TS6059: File '~/Projects/vitch/ts-interface/apps/ts-interface/app/app.js' is not under 'rootDir' '~/Projects/vitch/ts-interface/apps/ts-interface/tests'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '../app' in '~/Projects/vitch/ts-interface/apps/ts-interface/tests/tsconfig.json'

  apps/ts-interface/tests/tsconfig.json:17:32
    17   "include": [".", "../types", "../app"],
                                      ~~~~~~~~
    File is matched by include pattern specified here.

error TS6059: File '~/Projects/vitch/ts-interface/apps/ts-interface/app/bar/moes.ts' is not under 'rootDir' '~/Projects/vitch/ts-interface/apps/ts-interface/tests'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '../app' in '~/Projects/vitch/ts-interface/apps/ts-interface/tests/tsconfig.json'

  apps/ts-interface/tests/tsconfig.json:17:32
    17   "include": [".", "../types", "../app"],
                                      ~~~~~~~~
    File is matched by include pattern specified here.

error TS6059: File '~/Projects/vitch/ts-interface/apps/ts-interface/app/components/demo-one.ts' is not under 'rootDir' '~/Projects/vitch/ts-interface/apps/ts-interface/tests'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '../app' in '~/Projects/vitch/ts-interface/apps/ts-interface/tests/tsconfig.json'

  apps/ts-interface/tests/tsconfig.json:17:32
    17   "include": [".", "../types", "../app"],
                                      ~~~~~~~~
    File is matched by include pattern specified here.

error TS6059: File '~/Projects/vitch/ts-interface/apps/ts-interface/app/router.js' is not under 'rootDir' '~/Projects/vitch/ts-interface/apps/ts-interface/tests'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '../app' in '~/Projects/vitch/ts-interface/apps/ts-interface/tests/tsconfig.json'

  apps/ts-interface/tests/tsconfig.json:17:32
    17   "include": [".", "../types", "../app"],
                                      ~~~~~~~~
    File is matched by include pattern specified here.
...skipping...
    Matched by include pattern '../app' in '~/Projects/vitch/ts-interface/apps/ts-interface/tests/tsconfig.json'

  apps/ts-interface/tests/tsconfig.json:17:32
    17   "include": [".", "../types", "../app"],
                                      ~~~~~~~~
    File is matched by include pattern specified here.

error TS6059: File '~/Projects/vitch/ts-interface/apps/ts-interface/app/bar/moes.ts' is not under 'rootDir' '~/Projects/vitch/ts-interface/apps/ts-interface/tests'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '../app' in '~/Projects/vitch/ts-interface/apps/ts-interface/tests/tsconfig.json'

  apps/ts-interface/tests/tsconfig.json:17:32
    17   "include": [".", "../types", "../app"],
                                      ~~~~~~~~
    File is matched by include pattern specified here.

error TS6059: File '~/Projects/vitch/ts-interface/apps/ts-interface/app/components/demo-one.ts' is not under 'rootDir' '~/Projects/vitch/ts-interface/apps/ts-interface/tests'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '../app' in '~/Projects/vitch/ts-interface/apps/ts-interface/tests/tsconfig.json'

  apps/ts-interface/tests/tsconfig.json:17:32
    17   "include": [".", "../types", "../app"],
                                      ~~~~~~~~
    File is matched by include pattern specified here.

error TS6059: File '~/Projects/vitch/ts-interface/apps/ts-interface/app/router.js' is not under 'rootDir' '~/Projects/vitch/ts-interface/apps/ts-interface/tests'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '../app' in '~/Projects/vitch/ts-interface/apps/ts-interface/tests/tsconfig.json'

  apps/ts-interface/tests/tsconfig.json:17:32
    17   "include": [".", "../types", "../app"],
                                      ~~~~~~~~
    File is matched by include pattern specified here.

error TS6059: File '~/Projects/vitch/ts-interface/apps/ts-interface/app/services/foo-bar.ts' is not under 'rootDir' '~/Projects/vitch/ts-interface/apps/ts-interface/tests'. 'rootDir' is expected to contain all source files.
  The file is in the program because:
    Matched by include pattern '../app' in '~/Projects/vitch/ts-interface/apps/ts-interface/tests/tsconfig.json'

  apps/ts-interface/tests/tsconfig.json:17:32
    17   "include": [".", "../types", "../app"],
                                      ~~~~~~~~
    File is matched by include pattern specified here.

Found 5 errors.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```